### PR TITLE
Fix undefined method in ApiClient

### DIFF
--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -263,6 +263,36 @@ class ApiClient {
     }
   }
 
+  // Authentication Methods
+  Future<AuthModel> authenticateWithBackend(String token) async {
+    try {
+      dev.log('Authenticating with backend using token...', name: 'ApiClient');
+      final response = await _client
+          .post(
+            Uri.parse('$_baseUrl/api/auth/verify'),
+            headers: _defaultHeaders,
+            body: jsonEncode({
+              'token': token,
+            }),
+          )
+          .timeout(const Duration(seconds: 30));
+
+      if (response.statusCode == 200) {
+        final body = jsonDecode(response.body);
+        final authModel = AuthModel.fromJson(body);
+        await _storeAuth(authModel);
+        dev.log('Authentication successful', name: 'ApiClient');
+        return authModel;
+      } else {
+        dev.log('Authentication failed with status: ${response.statusCode}', name: 'ApiClient-ERROR');
+        throw AuthException('Authentication failed. Invalid token.');
+      }
+    } catch (e) {
+      dev.log('Error during authentication: $e', name: 'ApiClient-ERROR');
+      throw _handleError(e);
+    }
+  }
+
   // User Profile Methods
   Future<Map<String, dynamic>> getUserProfile() async {
     try {


### PR DESCRIPTION
Add `authenticateWithBackend` method to `ApiClient` to resolve compilation error and enable authentication.

The `test_auth_debug.dart` file was attempting to call `apiClient.authenticateWithBackend('test-token')`, but this method was not defined in the `ApiClient` class, leading to a compilation error. This PR adds the missing method to allow the test authentication flow to function correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to authenticate and verify tokens directly with the backend, improving login and authentication workflows. 

* **Bug Fixes**
  * Improved error handling and messaging for failed authentication attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->